### PR TITLE
Delete print statements

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+0.5.12 (JJ)
+* Removed print statements from code that were used for testing.
+* Since all we care about is the index, removed line that added 
+  shift back to the k-point in `symmetryReduceKpointList`.
+
+
 0.5.11 (GLWH)
 * At the end of the generateFullKpointList routine, I
 removed the loop that knocked all the kpoints into the first unit

--- a/src/generateKpoints.f90
+++ b/src/generateKpoints.f90
@@ -416,6 +416,7 @@ CONTAINS
           ! write(*,'("roKpt: ",3(f6.3,1x),i3)') roKpt
           ! write(*,'("into cell: ",3(f6.3,1x),i3)') roKpt
           ! write(*,'("icKpt: ",3(f6.3,1x),i3)') roKpt
+          
           ! Unshift the k-point temporarily to check if it still is a member of the lattice
           roKpt = roKpt - shift
           ! write(*,'("no shift: ",3(f6.3,1x),i3)') roKpt          
@@ -424,10 +425,11 @@ CONTAINS
              zz = zz + 1
              cycle
           endif
-          ! write(*,'(3(1x,f7.3))') (SymOps(i,:,iOp),i=1,3)          
+          ! write(*,'(3(1x,f7.3))') (SymOps(i,:,iOp),i=1,3)
           
           idx = findKptIndex(roKpt, InvK, L_long, D_long, eps)
-          ! write(*,'("rotated index: ",i7)') idx          
+          ! write(*,'("rotated index: ",i7)') idx
+          
           ! Reshift the k-point before finding its index
           roKpt = roKpt + shift
           ! write(*,'("with shift: ",3(f6.3,1x),i3)') roKpt


### PR DESCRIPTION
Fixes #8 
Deleted print statements.
Added white space where code looked congested.
Removed unnecessary shift.
Fixed minor typo that kept code from compiling.